### PR TITLE
Add full tournament test

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This project provides a small interface for running "tournaments" between langua
    - `NUM_GENERATIONS`
    - `OPENAI_API_BASE`
    - `OPENAI_API_KEY`
+   - `GENERATE_MODEL`
+   - `SCORE_MODEL`
+   - `PAIRWISE_MODEL`
    - `ENABLE_SCORE_FILTER`
    - `ENABLE_PAIRWISE_FILTER`
 2. Install dependencies (example with `pip`):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,112 @@
+import sys, os, types, json
+from unittest.mock import patch, MagicMock
+
+# Ensure project root in path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Provide dummy litellm module so import succeeds
+fake_litellm = types.ModuleType('litellm')
+fake_litellm.completion = MagicMock()
+sys.modules.setdefault('litellm', fake_litellm)
+
+# Provide dummy dotenv module
+fake_dotenv = types.ModuleType('dotenv')
+fake_dotenv.load_dotenv = MagicMock()
+sys.modules.setdefault('dotenv', fake_dotenv)
+
+# Dummy gradio module so import succeeds
+fake_gradio = types.ModuleType('gradio')
+fake_gradio.Interface = MagicMock(return_value=MagicMock(launch=MagicMock()))
+fake_gradio.Textbox = MagicMock
+fake_gradio.Number = MagicMock
+fake_gradio.Checkbox = MagicMock
+fake_gradio.Plot = MagicMock
+sys.modules.setdefault('gradio', fake_gradio)
+
+# Dummy tqdm module for write method
+class FakeTqdmModule(types.ModuleType):
+    def __init__(self):
+        super().__init__('tqdm')
+        self.write = MagicMock()
+    def __call__(self, iterable=None, total=None):
+        return iterable
+
+fake_tqdm_mod = FakeTqdmModule()
+fake_tqdm_mod.tqdm = fake_tqdm_mod
+sys.modules.setdefault('tqdm', fake_tqdm_mod)
+
+# Dummy matplotlib module
+fake_plt = types.ModuleType('matplotlib.pyplot')
+fake_plt.figure = MagicMock(return_value='fig')
+fake_plt.hist = MagicMock()
+fake_matplotlib = types.ModuleType('matplotlib')
+fake_matplotlib.pyplot = fake_plt
+sys.modules.setdefault('matplotlib', fake_matplotlib)
+sys.modules.setdefault('matplotlib.pyplot', fake_plt)
+
+import main
+
+class DummyFuture:
+    def __init__(self, func, *args):
+        self._func = func
+        self._args = args
+    def result(self):
+        return self._func(*self._args)
+
+class DummyExecutor:
+    def __init__(self, *args, **kwargs):
+        pass
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+    def submit(self, func, *args):
+        return DummyFuture(func, *args)
+    def map(self, func, iterable):
+        for item in iterable:
+            yield func(item)
+
+class DummyTqdm:
+    def __call__(self, iterable=None, total=None):
+        return iterable
+    def write(self, msg):
+        pass
+
+def test_run_tournament_full_loop():
+    dummy_tqdm = DummyTqdm()
+    with patch('main.generate_players') as mock_gen, \
+         patch('main.prompt_score') as mock_score, \
+         patch('main.prompt_pairwise') as mock_pair, \
+         patch('main.ThreadPoolExecutor', return_value=DummyExecutor()) as MockExec, \
+         patch('main.as_completed', new=lambda futs: futs), \
+         patch('main.tqdm', new=dummy_tqdm), \
+         patch('main.plt.figure', return_value='fig'), \
+         patch('main.plt.hist'):
+        mock_gen.return_value = ['p1', 'p2', 'p3', 'p4']
+        scores = {'p1':3, 'p2':2, 'p3':1, 'p4':0}
+        mock_score.side_effect = lambda instr, cl, block, player, **kw: json.dumps({'score': scores[player]})
+        mock_pair.side_effect = lambda instr, block, a, b, **kw: json.dumps({'winner': 'A'})
+
+        results = list(main.run_tournament(
+            api_base='b',
+            api_token='k',
+            generate_model='gm',
+            score_model='sm',
+            pairwise_model='pm',
+            instruction_input='instr',
+            criteria_input='c1,c2',
+            n_gen=4,
+            pool_size=2,
+            num_top_picks=1,
+            max_workers=1,
+            enable_score_filter=True,
+            enable_pairwise_filter=True,
+        ))
+
+    process_log, hist_fig, top_picks = results[-1]
+    assert 'Done' in process_log
+    assert hist_fig == 'fig'
+    assert top_picks.strip() in {'p1', 'p2'}
+    mock_gen.assert_called_once_with('instr', 4, model='gm', api_base='b', api_key='k')
+    assert mock_score.call_count == 4
+    assert mock_pair.called

--- a/tests/test_tournament_utils.py
+++ b/tests/test_tournament_utils.py
@@ -25,22 +25,26 @@ def make_response(contents):
 def test_generate_players():
     resp = make_response([" player1 ", "player2\n"])
     with patch('tournament_utils.completion', return_value=resp) as mock_comp:
-        players = tu.generate_players('instr', 2, model='m')
-        mock_comp.assert_called_once_with(model='m', messages=[{'role': 'user', 'content': 'instr'}], n=2)
+        players = tu.generate_players('instr', 2, model='m', api_base='b', api_key='k')
+        mock_comp.assert_called_once_with(model='m', messages=[{'role': 'user', 'content': 'instr'}], n=2, api_base='b', api_key='k')
         assert players == ['player1', 'player2']
 
 
 def test_prompt_score():
     resp = make_response([" {\"score\": [5]} "])
     with patch('tournament_utils.completion', return_value=resp) as mock_comp:
-        result = tu.prompt_score('instr', ['c1'], 'block', 'pl', model='m')
+        result = tu.prompt_score('instr', ['c1'], 'block', 'pl', model='m', api_base='b', api_key='k')
         mock_comp.assert_called_once()
+        assert mock_comp.call_args.kwargs['api_base'] == 'b'
+        assert mock_comp.call_args.kwargs['api_key'] == 'k'
         assert result == '{"score": [5]}'
 
 
-def test_prompt_play():
+def test_prompt_pairwise():
     resp = make_response([" {\"winner\": \"A\"} "])
     with patch('tournament_utils.completion', return_value=resp) as mock_comp:
-        result = tu.prompt_play('instr', 'block', 'A text', 'B text', model='m')
+        result = tu.prompt_pairwise('instr', 'block', 'A text', 'B text', model='m', api_base='b', api_key='k')
         mock_comp.assert_called_once()
+        assert mock_comp.call_args.kwargs['api_base'] == 'b'
+        assert mock_comp.call_args.kwargs['api_key'] == 'k'
         assert result == '{"winner": "A"}'


### PR DESCRIPTION
## Summary
- create a new unit test exercising `run_tournament`
- emulate external packages so `main` can be imported in tests
- verify API options are forwarded and that a full run yields expected output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d7a4ea34083329cfc2b3a53e06238