### PR TITLE
Add token usage tracking and output logging

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -82,10 +82,10 @@ def test_run_tournament_full_loop():
          patch('main.tqdm', new=dummy_tqdm), \
          patch('main.plt.figure', return_value='fig'), \
          patch('main.plt.hist'):
-        mock_gen.return_value = ['p1', 'p2', 'p3', 'p4']
+        mock_gen.return_value = (['p1', 'p2', 'p3', 'p4'], {'prompt_tokens':1,'completion_tokens':1})
         scores = {'p1':3, 'p2':2, 'p3':1, 'p4':0}
-        mock_score.side_effect = lambda instr, cl, block, player, **kw: json.dumps({'score': scores[player]})
-        mock_pair.side_effect = lambda instr, block, a, b, **kw: json.dumps({'winner': 'A'})
+        mock_score.side_effect = lambda instr, cl, block, player, **kw: (json.dumps({'score': scores[player]}), {'prompt_tokens':1,'completion_tokens':1})
+        mock_pair.side_effect = lambda instr, block, a, b, **kw: (json.dumps({'winner': 'A'}), {'prompt_tokens':1,'completion_tokens':1})
 
         results = list(main.run_tournament(
             api_base='b',
@@ -103,10 +103,11 @@ def test_run_tournament_full_loop():
             enable_pairwise_filter=True,
         ))
 
-    process_log, hist_fig, top_picks = results[-1]
+    process_log, hist_fig, top_picks, usage = results[-1]
     assert 'Done' in process_log
     assert hist_fig == 'fig'
     assert top_picks.strip() in {'p1', 'p2'}
-    mock_gen.assert_called_once_with('instr', 4, model='gm', api_base='b', api_key='k')
+    mock_gen.assert_called_once_with('instr', 4, model='gm', api_base='b', api_key='k', return_usage=True)
+    assert 'Prompt tokens' in usage
     assert mock_score.call_count == 4
     assert mock_pair.called


### PR DESCRIPTION
## Summary
- update tournament utilities to optionally return usage info
- log and sum token usage in tournament flow
- output all generated completions
- show token usage in Gradio interface
- update unit tests for new return values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d846fc9648332ad4706fffb464786