### PR TITLE
Add retry logic to model calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ This project provides a small interface for running "tournaments" between langua
 
 The interface will generate multiple answers, optionally filter them by score and run a pairwise tournament to select the best outputs.
 
+## Terminology
+
+- *Judge* refers to both the **Score Model** and **Pairwise Model**.
+- When instructions mention **updating the LLM**, update the **Generation**, **Score**, and **Pairwise** models together.
+- *Output*, *answer*, or *response* are all considered the same as a **player** in the tournament.
+

--- a/tests/test_tournament_utils.py
+++ b/tests/test_tournament_utils.py
@@ -23,10 +23,13 @@ def make_response(contents):
 
 
 def test_generate_players():
-    resp = make_response([" player1 ", "player2\n"])
-    with patch('tournament_utils.completion', return_value=resp) as mock_comp:
+    resp1 = make_response([" player1 "])
+    resp2 = make_response(["player2\n"])
+    with patch('tournament_utils.completion', side_effect=[resp1, resp2]) as mock_comp:
         players = tu.generate_players('instr', 2, model='m', api_base='b', api_key='k')
-        mock_comp.assert_called_once_with(model='m', messages=[{'role': 'user', 'content': 'instr'}], n=2, api_base='b', api_key='k')
+        assert mock_comp.call_count == 2
+        for call in mock_comp.call_args_list:
+            assert call.kwargs == {'model': 'm', 'messages': [{'role': 'user', 'content': 'instr'}], 'n': 1, 'api_base': 'b', 'api_key': 'k'}
         assert players == ['player1', 'player2']
 
 

--- a/tests/test_tournament_utils.py
+++ b/tests/test_tournament_utils.py
@@ -33,6 +33,13 @@ def test_generate_players():
         assert players == ['player1', 'player2']
 
 
+def test_generate_players_drops_failed():
+    with patch('tournament_utils.completion', side_effect=Exception('boom')) as m:
+        players = tu.generate_players('instr', 1, model='m')
+        assert players == []
+        assert m.call_count == 5
+
+
 def test_prompt_score():
     resp = make_response([" {\"score\": [5]} "])
     with patch('tournament_utils.completion', return_value=resp) as mock_comp:

--- a/tournament_utils.py
+++ b/tournament_utils.py
@@ -2,7 +2,10 @@ from litellm import completion
 
 
 def _completion_with_retry(*args, retries: int = 5, **kwargs):
-    """Call ``completion`` with retry logic."""
+    """Call ``completion`` with retry logic.
+
+    Returns ``None`` if all attempts fail.
+    """
     for _ in range(retries):
         try:
             return completion(*args, **kwargs)


### PR DESCRIPTION
## Summary
- document terminology around judges and players
- implement retry mechanism when calling LLMs
- adjust generate_players behaviour to retry each generation individually
- update unit tests for new logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea565ce6c833282014132f5940c3e