### PR TITLE
Switch pairwise tournament to Elo rating

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This project provides a small interface for running "tournaments" between langua
    ```
 4. Open the displayed local URL. At the top of the page you can optionally override the API base path and token (the token field is blank by default). Additional settings let you configure score and pairwise filtering.
 
-The interface will generate multiple answers, optionally filter them by score and run a pairwise tournament to select the best outputs.
+The interface will generate multiple answers, optionally filter them by score and run a pairwise tournament to select the best outputs. Results from previous pairwise comparisons are cached, so duplicate matches are skipped for faster tournaments. Pairwise results are aggregated using an Elo rating system to rank the players.
 
 ## Terminology
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -114,7 +114,7 @@ def test_run_tournament_full_loop():
     process_log, hist_fig, top_picks, usage = results[-1]
     assert 'Done' in process_log
     assert hist_fig == 'fig'
-    assert top_picks.strip() in {'p1', 'p2'}
+    assert any(p in top_picks for p in {'p1', 'p2'})
     mock_gen.assert_called_once_with('instr', 4, model='gm', api_base='b', api_key='k', temperature=1, thinking=True, return_usage=True)
     assert 'Score completion' in process_log
     assert 'Pairwise completion' in process_log
@@ -161,5 +161,5 @@ def test_run_tournament_pairwise_odd_players():
 
     process_log, fig, top_picks, usage = results[-1]
     assert 'Done' in process_log
-    assert top_picks.strip() in {'p1', 'p2', 'p3'}
-    assert mock_pair.call_count == 5
+    assert any(p in top_picks for p in {'p1', 'p2', 'p3'})
+    assert mock_pair.call_count == 3


### PR DESCRIPTION
## Summary
- rank players using an Elo rating system
- display final Elo score for each top pick
- cache pairwise match results
- update README and tests for Elo-based ranking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f00f05ab48332926ff31b575283df