### PR TITLE
Switch judges to plaintext verdict output

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -87,8 +87,14 @@ def test_run_tournament_full_loop():
          patch('main.plt.bar'):
         mock_gen.return_value = (['p1', 'p2', 'p3', 'p4'], {'prompt_tokens':1,'completion_tokens':1})
         scores = {'p1':3, 'p2':2, 'p3':1, 'p4':0}
-        mock_score.side_effect = lambda instr, cl, block, player, **kw: (json.dumps({'score': scores[player]}), {'prompt_tokens':1,'completion_tokens':1})
-        mock_pair.side_effect = lambda instr, block, a, b, **kw: (json.dumps({'winner': 'A'}), {'prompt_tokens':1,'completion_tokens':1})
+        mock_score.side_effect = lambda instr, cl, block, player, **kw: (
+            f"Final verdict: [{scores[player]}]",
+            {'prompt_tokens':1,'completion_tokens':1}
+        )
+        mock_pair.side_effect = lambda instr, block, a, b, **kw: (
+            "Final verdict: A",
+            {'prompt_tokens':1,'completion_tokens':1}
+        )
 
         results = list(main.run_tournament(
             api_base='b',
@@ -138,7 +144,10 @@ def test_run_tournament_pairwise_odd_players():
          patch('main.plt.hist'), \
          patch('main.plt.bar'):
         mock_gen.return_value = (['p1', 'p2', 'p3'], {'prompt_tokens':1,'completion_tokens':1})
-        mock_pair.side_effect = lambda instr, block, a, b, **kw: (json.dumps({'winner':'A'}), {'prompt_tokens':1,'completion_tokens':1})
+        mock_pair.side_effect = lambda instr, block, a, b, **kw: (
+            "Final verdict: A",
+            {'prompt_tokens':1,'completion_tokens':1}
+        )
 
         results = list(main.run_tournament(
             api_base='b',

--- a/tests/test_tournament_utils.py
+++ b/tests/test_tournament_utils.py
@@ -31,25 +31,25 @@ def test_generate_players():
 
 
 def test_prompt_score():
-    resp = make_response([" {\"score\": [5]} "])
+    resp = make_response(["Final verdict: [5]"])
     with patch('tournament_utils.completion', return_value=resp) as mock_comp:
         result = tu.prompt_score('instr', ['c1'], 'block', 'pl', model='m', api_base='b', api_key='k', temperature=0.2, include_instruction=False)
         mock_comp.assert_called_once()
         assert mock_comp.call_args.kwargs['api_base'] == 'b'
         assert mock_comp.call_args.kwargs['api_key'] == 'k'
         assert mock_comp.call_args.kwargs['temperature'] == 0.2
-        assert result == '{"score": [5]}'
+        assert result == 'Final verdict: [5]'
 
 
 def test_prompt_pairwise():
-    resp = make_response([" {\"winner\": \"A\"} "])
+    resp = make_response(["Final verdict: A"])
     with patch('tournament_utils.completion', return_value=resp) as mock_comp:
         result = tu.prompt_pairwise('instr', 'block', 'A text', 'B text', model='m', api_base='b', api_key='k', temperature=0.3, include_instruction=False)
         mock_comp.assert_called_once()
         assert mock_comp.call_args.kwargs['api_base'] == 'b'
         assert mock_comp.call_args.kwargs['api_key'] == 'k'
         assert mock_comp.call_args.kwargs['temperature'] == 0.3
-        assert result == '{"winner": "A"}'
+        assert result == 'Final verdict: A'
 
 
 def test_thinking_passed_to_completion():

--- a/tournament_utils.py
+++ b/tournament_utils.py
@@ -63,18 +63,21 @@ def prompt_score(
     explain: bool = False,
     return_usage: bool = False,
 ) -> str | tuple[str, object]:
-    """Return a JSON score string evaluating `player` on the criteria."""
+    """Return a plaintext score evaluation for `player`."""
     example_scores = ", ".join(["1-10"] * len(criteria_list)) or "1-10"
     prompt = f"""Evaluate the output below on the following criteria:
 {criteria_block}
 
+{'Provide detailed reasons in English.' if explain else 'Provide a short reason.'}
 """
+
     if explain:
-        prompt += f"""
-Provide detailed reasons in English for each criterion.
-Return JSON exactly like: {{"reasons":"","scores": [{example_scores}]}}.""".strip()
+        prompt += "Respond in plain text with two sections exactly like:\n" \
+                 "Reasons: <your reasoning>\n" \
+                 f"Final verdict: [{example_scores}]"
     else:
-        prompt += f"""Return JSON exactly like: {{"scores": [{example_scores}]}}."""
+        prompt += "Respond in plain text exactly like:\n" \
+                 f"Final verdict: [{example_scores}]"
 
     if include_instruction:
         prompt += f"\n\nInstruction:\n{instruction}"
@@ -108,18 +111,25 @@ def prompt_pairwise(
     explain: bool = False,
     return_usage: bool = False,
 ) -> str | tuple[str, object]:
-    """Return which player wins in JSON using the given criteria."""
+    """Return which player wins in plaintext using the given criteria."""
     prompt = f"""Compare the two players below using:
 {criteria_block}
 
+{'Provide detailed reasons in English.' if explain else 'Provide a short reason.'}
 """
 
+    verdict_example = "Final verdict: A or Final verdict: B"
     if explain:
-        prompt += f"""
-Provide detailed reasons in English for each criterion.
-Return JSON exactly like: {{"reasons":"","winner": "A"}} or {{"reasons":"","winner": "B"}}.""".strip()
+        prompt += (
+            "Respond in plain text with two sections exactly like:\n"
+            "Reasons: <your reasoning>\n"
+            f"{verdict_example}"
+        )
     else:
-        prompt += f"""Return JSON exactly like: {{"winner": "A"}} or {{"winner": "B"}}."""
+        prompt += (
+            "Respond in plain text exactly like:\n"
+            f"{verdict_example}"
+        )
 
     if include_instruction:
         prompt += f"\n\nInstruction:\n{instruction}"


### PR DESCRIPTION
## Summary
- switch judge prompts from JSON to plaintext with `Reasons` and `Final verdict` sections
- add regex based verdict parser
- update scoring and pairwise logic to parse plaintext
- adjust tests for new response format
- keep explain option in prompts and show both choices for pairwise verdict

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fb05cbf448332a4c33e3e1b05141b